### PR TITLE
fix: add missing page aliases

### DIFF
--- a/modules/bici/pages/overview.adoc
+++ b/modules/bici/pages/overview.adoc
@@ -1,5 +1,5 @@
 = Bonita Intelligent Continuous Improvement
-:page-aliases: release_notes.adoc
+:page-aliases: index.adoc, release_notes.adoc
 
 image::ici.png[Bonita ICI logo]
 

--- a/modules/bici/pages/test_data.adoc
+++ b/modules/bici/pages/test_data.adoc
@@ -1,4 +1,5 @@
 = Test data
+:page-aliases: send_data.adoc
 
 To be able to reach even better predictions, we need to train our algorithm on real-world data.
 


### PR DESCRIPTION
We need to be able to access to 'labs/latest/bici/' as the redirects for the old
bici 1.x versions target this url. Otherwise, an http 404 error is sent.
Add a alias for 'send_data' renamed into 'test_data'