### PR TITLE
ci(surge-preview): use the documentation-site repository action

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -10,33 +10,17 @@ on:
       - '.github/workflows/build-pr-preview.yml'
 jobs:
   build_preview:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write # surge-preview write PR comments
     env:
       COMPONENT_NAME: labs
-      # Except if you want to test in progress work that your content depends on, keep it set to master
-      DOC_SITE_BRANCH: master
-      PR_NUMBER: ${{ github.event.pull_request.number }}
+      BRANCH_NAME: ${{ github.head_ref }}
     steps:
-      - name: Get documentation site source code
-        if: github.event.action != 'closed'
-        run: |
-          # Remove existing .git directory
-          rm -rf *
-          git clone --depth 1 --single-branch --branch ${DOC_SITE_BRANCH} https://github.com/bonitasoft/bonitasoft.github.io.git .
-      - name: Compute environment variables
-        run: |
-          echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF#refs/heads/})" >> $GITHUB_ENV
-          # the surge-preview action generates https://{{repository.owner}}-{{repository.name}}-{{job.name}}-pr-{{pr.number}}.surge.sh
-          repo_owner_and_name=$(echo "${{github.repository}}" | sed 's/\//-/g')
-          echo PREVIEW_URL=https://$repo_owner_and_name-"${{github.job}}"-pr-$PR_NUMBER.surge.sh >> $GITHUB_ENV
-      - name: Publish preview
-        uses: afc163/surge-preview@v1
+      - name: Build and publish PR preview
+        uses: bonitasoft/bonita-documentation-site/.github/actions/build-and-publish-pr-preview/@master
         with:
-          surge_token: ${{ secrets.SURGE_TOKEN_DOC }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          dist: build/site
-          failOnError: true
-          teardown: 'true'
-          build: |
-            ./build-preview.bash --branch "${{ env.BRANCH_NAME }}" --component "${{ env.COMPONENT_NAME }}" --pr "${{ env.PR_NUMBER }}" --site-url "${{ env.PREVIEW_URL }}"
-            ls -lh build/site
+          surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          build-preview-command: |-
+            ./build-preview.bash --component "${{ env.COMPONENT_NAME }}" --branch "${{ env.BRANCH_NAME }}"


### PR DESCRIPTION
This avoids duplication and provide more features.

covers https://github.com/bonitasoft/bonita-documentation-site/issues/239
covers https://github.com/bonitasoft/bonita-documentation-site/issues/270