### PR TITLE
feat: use 'latest' as display version

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,7 +1,6 @@
 name: labs
 version: latest
 title: Labs
-display_version: labs
 asciidoc:
   attributes:
     # page attributes


### PR DESCRIPTION
This avoids to have a version with the same name as the component. It is more explicit that there is only a single version and it is consistent with the `cloud` component.

### Screenshots

before (prod site) | now (preview)
---- | -----
![image](https://user-images.githubusercontent.com/27200110/200259446-f6c9016b-676e-4a6d-9237-b1b089f25328.png) | ![image](https://user-images.githubusercontent.com/27200110/200259126-4860a2d1-d773-486f-b362-093f4decb1fd.png)

