### PR TITLE
ci: simplify the 'PR preview' workflow

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -13,14 +13,12 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       pull-requests: write # surge-preview write PR comments
-    env:
-      COMPONENT_NAME: labs
-      BRANCH_NAME: ${{ github.head_ref }}
     steps:
       - name: Build and publish PR preview
+#        TODO restore usage of the master branch
         uses: bonitasoft/bonita-documentation-site/.github/actions/build-and-publish-pr-preview@ci/preview_action_add_ignore-errors_input
         with:
-          doc-site-branch: ci/preview_action_add_ignore-errors_input # temp to test the new feature
+          doc-site-branch: ci/preview_action_add_ignore-errors_input # TODO remove after testing the new feature
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           component-name: labs

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -23,5 +23,5 @@ jobs:
           doc-site-branch: ci/preview_action_add_ignore-errors_input # temp to test the new feature
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          component: labs
+          component-name: labs
           ignore-errors: false

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -18,9 +18,10 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref }}
     steps:
       - name: Build and publish PR preview
-        uses: bonitasoft/bonita-documentation-site/.github/actions/build-and-publish-pr-preview/@master
+        uses: bonitasoft/bonita-documentation-site/.github/actions/build-and-publish-pr-preview@ci/preview_action_add_ignore-errors_input
         with:
+          doc-site-branch: ci/preview_action_add_ignore-errors_input # temp to test the new feature
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          build-preview-command: |-
-            ./build-preview.bash --component "${{ env.COMPONENT_NAME }}" --branch "${{ env.BRANCH_NAME }}"
+          component: labs
+          ignore-errors: false

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -15,10 +15,8 @@ jobs:
       pull-requests: write # surge-preview write PR comments
     steps:
       - name: Build and publish PR preview
-#        TODO restore usage of the master branch
-        uses: bonitasoft/bonita-documentation-site/.github/actions/build-and-publish-pr-preview@ci/preview_action_add_ignore-errors_input
+        uses: bonitasoft/bonita-documentation-site/.github/actions/build-and-publish-pr-preview@master
         with:
-          doc-site-branch: ci/preview_action_add_ignore-errors_input # TODO remove after testing the new feature
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           component-name: labs

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,6 +1,9 @@
 = Labs Program
 :description: An explanation of the Labs Program and how to benefit from it.
 
+// TODO temp to generate xref validation errors
+xref:unknown.adoc[Unknown page]
+
 image::Lab_icon.png[Labs logo,200,100]
 
 The Labs Program has been created to experiment projects with a potential high value in the Digital Process Automation field.

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,9 +1,6 @@
 = Labs Program
 :description: An explanation of the Labs Program and how to benefit from it.
 
-// TODO temp to generate xref validation errors
-xref:unknown.adoc[Unknown page]
-
 image::Lab_icon.png[Labs logo,200,100]
 
 The Labs Program has been created to experiment projects with a potential high value in the Digital Process Automation field.


### PR DESCRIPTION
The labs component has no xref to other components, so the validation can be done while building the preview which is then deployed to Surge.
The action provided by the `bonita-documentation-site` repository manages most of the configuration: only pass the `labs` component and activate xref validation.


### Tests

✔️ introduce invalid xref to ensure that the `ignore-errors` input correctly works when set to `false` fa886be2
  - https://github.com/bonitasoft/bonita-labs-doc/actions/runs/3418987678/jobs/5691949527
  - `ERROR (asciidoctor): target of xref not found: unknown.adoc`