### PR TITLE
ci: use bonitasoft/actions pr-title-conventional-commits

### DIFF
--- a/.github/workflows/commit-message-check-format.yml
+++ b/.github/workflows/commit-message-check-format.yml
@@ -1,4 +1,4 @@
-name: Commit Message format check 
+name: Commit Message format check
 
 on:
   pull_request_target:

--- a/.github/workflows/commit-message-check-format.yml
+++ b/.github/workflows/commit-message-check-format.yml
@@ -1,19 +1,15 @@
 name: Commit Message format check 
 
 on:
-  pull_request:
-    branches: [master]
-    types: [opened, edited, synchronize]
+  pull_request_target:
+    # trigger when the PR title changes
+    types: [opened, edited, reopened]
 
 jobs:
-  check-for-cc:
-    runs-on: ubuntu-20.04
+  pr-title:
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write # post comments when the PR title doesn't match the "Conventional Commits" rules
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: check-for-cc
-        id: check-for-cc
-        uses: agenthunt/conventional-commit-checker-action@v1.0.0
-        with:
-          pr-body-regex: '(.*\n*)+(.*)'
+      - name: Check Pull Request title
+        uses: bonitasoft/actions/packages/pr-title-conventional-commits@v2


### PR DESCRIPTION
This action better conforms to Conventional Commits and provides guidelines to help to fix wrong PR titles.

### Status

It has been successfully tested in https://github.com/bonitasoft/bonita-apps-manager-doc/pull/3