### PR TITLE
ci: fail the "build-pr-preview" workflow on warning

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write # surge-preview write PR comments
     steps:
       - name: Build and publish PR preview
-        uses: bonitasoft/bonita-documentation-site/.github/actions/build-and-publish-pr-preview/@master
+        uses: bonitasoft/bonita-documentation-site/.github/actions/build-and-publish-pr-preview@master
         with:
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -15,11 +15,8 @@ jobs:
       pull-requests: write # surge-preview write PR comments
     steps:
       - name: Build and publish PR preview
-        # TMP use the branch of https://github.com/bonitasoft/bonita-documentation-site/pull/596
-        uses: bonitasoft/bonita-documentation-site/.github/actions/build-and-publish-pr-preview/@feat/add_fail_on_warning_options
+        uses: bonitasoft/bonita-documentation-site/.github/actions/build-and-publish-pr-preview/@master
         with:
-          # TMP use the branch of https://github.com/bonitasoft/bonita-documentation-site/pull/596
-          doc-site-branch: feat/add_fail_on_warning_options
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           component-name: labs

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -15,9 +15,12 @@ jobs:
       pull-requests: write # surge-preview write PR comments
     steps:
       - name: Build and publish PR preview
-        uses: bonitasoft/bonita-documentation-site/.github/actions/build-and-publish-pr-preview@master
+        # TMP use the branch of https://github.com/bonitasoft/bonita-documentation-site/pull/596
+        uses: bonitasoft/bonita-documentation-site/.github/actions/build-and-publish-pr-preview/@feat/add_fail_on_warning_options
         with:
+          # TMP use the branch of https://github.com/bonitasoft/bonita-documentation-site/pull/596
+          doc-site-branch: feat/add_fail_on_warning_options
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           component-name: labs
-          ignore-errors: false
+          fail-on-warning: true


### PR DESCRIPTION
Prevent to add new warnings in the documentation content.

### Tasks

- [x] verify that the workflow still pass
- [x] when https://github.com/bonitasoft/bonita-documentation-site/pull/596 is merged, update the workflow to use the master branch of the documentation-site repository