### PR TITLE
ci: run contribution checks on `pull_request_target`

### DIFF
--- a/.github/workflows/contribution-checks.yml
+++ b/.github/workflows/contribution-checks.yml
@@ -1,7 +1,7 @@
 name: Contribution checks
 
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   check_antora_content_guidelines:

--- a/modules/bici/pages/getting_started.adoc
+++ b/modules/bici/pages/getting_started.adoc
@@ -3,6 +3,8 @@
 
 Bonita Intelligent Continuous Improvement (BICI) configuration instructions.
 
+See https://documentation.bonitasoft.com/bici for more information.
+
 == Configure
 
 === Configure Profiles

--- a/modules/bici/pages/overview.adoc
+++ b/modules/bici/pages/overview.adoc
@@ -1,6 +1,5 @@
 = Bonita Intelligent Continuous Improvement
 :page-aliases: index.adoc, release_notes.adoc
-:description: A presentation of the BICI concept.
 
 image::ici.png[Bonita ICI logo]
 


### PR DESCRIPTION
There is no security issue here. The checks are done only on the updated file of the PR without doing tool installation, cache update or branch checkout.
Using this event allows to create PR comment when the PR is created from a forked repository.

### Resources

https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

covers https://github.com/bonitasoft/bonita-documentation-site/issues/685