### PR TITLE
fix: revert extra changes done by mistake

### DIFF
--- a/modules/bici/pages/architecture.adoc
+++ b/modules/bici/pages/architecture.adoc
@@ -6,6 +6,11 @@ Bonita Intelligent Continuous Improvement (BICI) extracts data of the Bonita Dat
 
 image::bici_architecture.png[Bonita Intelligent Continuous Improvement Add-on Architecture]
 
+See See https://documentation.bonitasoft.com/bici for more information.
+
+See xref:_anchor[wrong anchor]
+
+
 == Overview
 
 BICI connects to the Bonita Database, using its own connection pool to read events from the archives.

--- a/modules/bici/pages/architecture.adoc
+++ b/modules/bici/pages/architecture.adoc
@@ -6,11 +6,6 @@ Bonita Intelligent Continuous Improvement (BICI) extracts data of the Bonita Dat
 
 image::bici_architecture.png[Bonita Intelligent Continuous Improvement Add-on Architecture]
 
-See See https://documentation.bonitasoft.com/bici for more information.
-
-See xref:_anchor[wrong anchor]
-
-
 == Overview
 
 BICI connects to the Bonita Database, using its own connection pool to read events from the archives.

--- a/modules/bici/pages/getting_started.adoc
+++ b/modules/bici/pages/getting_started.adoc
@@ -3,8 +3,6 @@
 
 Bonita Intelligent Continuous Improvement (BICI) configuration instructions.
 
-See https://documentation.bonitasoft.com/bici/latest for more information.
-
 == Configure
 
 === Configure Profiles

--- a/modules/bici/pages/getting_started.adoc
+++ b/modules/bici/pages/getting_started.adoc
@@ -3,7 +3,7 @@
 
 Bonita Intelligent Continuous Improvement (BICI) configuration instructions.
 
-See https://documentation.bonitasoft.com/bici for more information.
+See https://documentation.bonitasoft.com/bici/latest for more information.
 
 == Configure
 

--- a/modules/bici/pages/overview.adoc
+++ b/modules/bici/pages/overview.adoc
@@ -1,8 +1,6 @@
 = Bonita Intelligent Continuous Improvement
 :page-aliases: index.adoc, release_notes.adoc
-
-missing desription attribute
-
+:description: A presentation of the BICI concept.
 
 image::ici.png[Bonita ICI logo]
 

--- a/modules/bici/pages/overview.adoc
+++ b/modules/bici/pages/overview.adoc
@@ -1,6 +1,9 @@
 = Bonita Intelligent Continuous Improvement
 :page-aliases: index.adoc, release_notes.adoc
 
+missing desription attribute
+
+
 image::ici.png[Bonita ICI logo]
 
 This Lab project is a proof-of-concept that validates the value of artificial intelligence (AI) in the field of operations management when operations are based on process automation and execution.


### PR DESCRIPTION
Some changes were done to ensure the the "contribution checks" workflow correctly runs. Unfortunately, this changes were pushed to production. So revert them.