### PR TITLE
ci: restore usage of the reusable workflow for "contribution checks"

### DIFF
--- a/.github/workflows/contribution-checks.yml
+++ b/.github/workflows/contribution-checks.yml
@@ -3,25 +3,8 @@ name: Contribution checks
 on:
   pull_request_target:
 
-# TODO temporarily use the content of the called workflow here to ease the debugging
-#jobs:
-#  check_antora_content_guidelines:
-#    permissions:
-#      pull-requests: write # "pr-antora-content-guidelines-checker" write PR comments when the PR doesn't match the "Guidelines"
-#    uses: bonitasoft/bonita-documentation-site/.github/workflows/_reusable_pr-antora-content-guidelines-checker.yml@master
-
 jobs:
-  checks:
+  check_antora_content_guidelines:
     permissions:
       pull-requests: write # "pr-antora-content-guidelines-checker" write PR comments when the PR doesn't match the "Guidelines"
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Check
-        # use the content of https://github.com/bonitasoft/actions/pull/129
-        uses: bonitasoft/actions/packages/pr-antora-content-guidelines-checker@feat/pr-antora-checker_better_support_pr-target
-        with:
-          attributes-to-check: ':description:'
-          files-to-check: 'adoc'
-          # WARN: Be aware that spaces after/before the coma are not trimmed by the action. This means that the spaces are part of the pattern.
-          forbidden-pattern-to-check: 'https://documentation.bonitasoft.com,link:https,link:http,link:,xref:https,xref:http,xref:_,xref:#,Bonita BPM'
-
+    uses: bonitasoft/bonita-documentation-site/.github/workflows/_reusable_pr-antora-content-guidelines-checker.yml@master


### PR DESCRIPTION
An alternative implementation was temporarily used to validate the new implementation of the `pr-antora-content-guidelines-checker` action.
A new release of the action is now available, so we can use the "reusable" workflow that will use this new release.