### PR TITLE
feat: hide BCD entry menu

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -6,5 +6,6 @@ asciidoc:
     # page attributes
     page-editable: true
     page-pagination: true # display links to previous/next pages at the bottom of the page
+    page-hide-components: 'bcd'
 nav:
   - modules/bici/taxonomy.adoc


### PR DESCRIPTION
As for recent Bonita versions and test-toolkit, we don't want to highlight BCD (which is deprecated) in the top menu.